### PR TITLE
Update user explanation in scenarios.py

### DIFF
--- a/pages/scenarios.py
+++ b/pages/scenarios.py
@@ -90,7 +90,7 @@ with create_container:
     '#### Portfolio Selection'
     'A pre-loaded portfolio of buildings will be shown below, corresponding to the same area as the event footprint selected above.'
     'In the near future, buildings data from the Global Exposure Model will be available to select here.'
-    "After selecting a combination of scenario and exposure portfolios, click on 'Create analysis', give it a name, and create the analysis."
+    "After selecting a combination of scenario and exposure portfolios, click on 'Create Analysis', give it a name, and create the analysis."
     'The Scenario Details button provides a description of the scenario selected.'
     'The Exposure Map button will show the distribution of building TIV (total insured value) in the selected portfolio.'
 


### PR DESCRIPTION
Added user explanation as text under each title on analyis selection and results pages. Suggested some changes to titles, and #26 references more user-friendly names of scenarios to be used please.

@benhayes21 / @vinulw please review format in which I've added the additional and merge ASAP as we need to show this to non-expert users soon.

Thanks